### PR TITLE
Require orb-note-actions

### DIFF
--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -74,6 +74,8 @@
 (eval-when-compile
   (require 'subr-x)
   (require 'cl-lib))
+;;;; org-roam-bibtex features
+(require 'orb-note-actions)
 
 (defvar org-ref-notes-function)
 


### PR DESCRIPTION
We need to require `orb-note-actions` in `org-roam-bibtex.el`.  Otherwise, `autoload` commands are not set.