### PR TITLE
Revert "Require orb-note-actions"

### DIFF
--- a/orb-note-actions.el
+++ b/orb-note-actions.el
@@ -43,6 +43,7 @@
 ;;; Code:
 ;; * Library requires
 
+(require 'org-roam-bibtex)
 (require 'warnings)
 (require 'cl-lib)
 ;; TODO: get rid of after we have our own format function

--- a/org-roam-bibtex.el
+++ b/org-roam-bibtex.el
@@ -74,8 +74,6 @@
 (eval-when-compile
   (require 'subr-x)
   (require 'cl-lib))
-;;;; org-roam-bibtex features
-(require 'orb-note-actions)
 
 (defvar org-ref-notes-function)
 


### PR DESCRIPTION
This reverts commit f0a65ae9b9fd779835dbea2b5ebfa40657f7d209.

Follows from the discussion in #13.